### PR TITLE
Add `call_semantics` option to select call command code

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,8 +67,10 @@ local tar, err = tnt:new({
     user = 'luser',
     password = 'some_password',
     socket_timeout = 2000,
+    call_semantics = 'new' -- can be 'new' or 'old'*
 })
 ```
+
 The above creates a connection object that connects to a tarantool
 server instance running on the loopback in port 3301, for user `luser`
 with password `some password`. See the
@@ -76,6 +78,12 @@ with password `some password`. See the
 for details on how to setup users and assigning privileges to them.
 
 The socket timeout (receive and send) is 2 seconds (2000 ms).
+
+\* The option `call_semantics` controls whether the code for the new call
+method (0x0a) or the old one (0x06) is used.
+The old method wraps every result in a table as described [here][binary-protocol].
+
+[binary-protocol]: https://www.tarantool.io/en/doc/2.2/dev_guide/internals/box_protocol/ 'Tarantool Binary Protocol'
 
 ### set_timeout
 

--- a/README.md
+++ b/README.md
@@ -82,6 +82,9 @@ The socket timeout (receive and send) is 2 seconds (2000 ms).
 \* The option `call_semantics` controls whether the code for the new call
 method (0x0a) or the old one (0x06) is used.
 The old method wraps every result in a table as described [here][binary-protocol].
+**The current default is 'old', but this might change in the future**.
+It is therefore suggested to set it manually to 'old' in projects that rely on
+the old behavior.
 
 [binary-protocol]: https://www.tarantool.io/en/doc/2.2/dev_guide/internals/box_protocol/ 'Tarantool Binary Protocol'
 

--- a/lib/resty/tarantool.lua
+++ b/lib/resty/tarantool.lua
@@ -195,15 +195,12 @@ function M.new(self, params)
   -- Create an object using the defaults.
   -- tarc = tarantool connection.
   local tarc = {
-    host = defaults.host,
-    port = defaults.port,
-    user =  defaults.user,
-    password = defaults.password,
-    socket_timeout = defaults.socket_timeout,
     -- If true it sends a custom header with the tarantool version.
     show_version_header = true,
-    call_semantics = defaults.call_semantics,
   }
+  for key, value in pairs(defaults) do
+	  tarc[key] = value
+  end
   -- Loop over the given parameters and assign the values accordingly.
   if params and type(params) == 'table' then
     for key, value in pairs(params) do


### PR DESCRIPTION
The old (0x06) returns a table with the return values of the function
call, where each value is wrapped in an array. The new command returns a
table that contains the values unwrapped.

This saves table allocations, thus creating less unnecessary work for
the garbage collector.

see also: #8