### PR TITLE
Add messagepack dependancy to rockspec

### DIFF
--- a/lua-resty-tarantool-scm-2.rockspec
+++ b/lua-resty-tarantool-scm-2.rockspec
@@ -10,7 +10,7 @@ description = {
    license = "MIT"
 }
 dependencies = {
-   "lua-messagepack ~> 5";
+   "lua-messagepack ~> 0.5";
 }
 build = {
    type = "builtin",

--- a/lua-resty-tarantool-scm-2.rockspec
+++ b/lua-resty-tarantool-scm-2.rockspec
@@ -1,5 +1,5 @@
 package = "lua-resty-tarantool"
-version = "scm-1"
+version = "scm-2"
 source = {
    url = "git+ssh://git@github.com/perusio/lua-resty-tarantool"
 }
@@ -8,6 +8,9 @@ description = {
    detailed = "Library for working with tarantool from nginx with the embedded Lua module for Openresty.",
    homepage = "github.com/perusio/lua-resty-tarantool",
    license = "MIT"
+}
+dependencies = {
+   "lua-messagepack ~> 5";
 }
 build = {
    type = "builtin",


### PR DESCRIPTION
I somehow missed this in my first pull request, but the MessagePack dependancy should obviously be listed in the rockspec.