### PR TITLE
fix socket timeout typo

### DIFF
--- a/lib/resty/tarantool.lua
+++ b/lib/resty/tarantool.lua
@@ -219,7 +219,7 @@ function M.new(self, params)
   end
   -- Set the socket timeout.
   if tarc.socket_timeout then
-    tcpsock:settimeout(tarc.tcpsocket_timeout)
+    tcpsock:settimeout(tarc.socket_timeout)
   end
 
   tarc.sock = tcpsock

--- a/lua-resty-tarantool-scm-3.rockspec
+++ b/lua-resty-tarantool-scm-3.rockspec
@@ -1,5 +1,5 @@
 package = "lua-resty-tarantool"
-version = "scm-2"
+version = "scm-3"
 source = {
    url = "git+ssh://git@github.com/perusio/lua-resty-tarantool"
 }


### PR DESCRIPTION
Fix socket timeout typo: `tarc.tcpsocket_timeout` -> `tarc.socket_timeout`